### PR TITLE
fix: dataset params

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ function App() {
   return (
     <InstantSearch
       indexName="076e26b3-13df-4920-811b-3d0caa0d3a1e"
-      searchClient={trieveSearchClient}
+      searchClient={searchClient}
     >
       <SearchBox />
       <Hits />

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+## Example react-instantsearch
+
+```ts
+import { InstantSearch, SearchBox, Hits } from "react-instantsearch";
+
+const trieveInstantsearchAdapter = new TrieveInstantsearchAdapter({
+  server: {
+    apiKey: "tr-xxxxxxxxxxx",
+    url: "https://api.trieve.ai",
+  },
+  searchType: "fulltext",
+});
+
+const searchClient = trieveInstantsearchAdapter.searchClient;
+
+function App() {
+  return (
+    <InstantSearch
+      indexName="076e26b3-13df-4920-811b-3d0caa0d3a1e"
+      searchClient={trieveSearchClient}
+    >
+      <SearchBox />
+      <Hits />
+    </InstantSearch>
+  );
+}
+
+export default App;
+```

--- a/src/TrieveInstantsearchAdapter.ts
+++ b/src/TrieveInstantsearchAdapter.ts
@@ -63,7 +63,7 @@ export default class TrieveInstantsearchAdapter {
           {
             headers: {
               Authorization: `Bearer ${this._serverConfig.apiKey}`,
-              "TR-Dataset": this._serverConfig.dataset,
+              "TR-Dataset": adaptedRequest.dataset,
             },
           }
         );
@@ -83,6 +83,7 @@ export default class TrieveInstantsearchAdapter {
     return {
       query: query.params?.query || " ",
       search_type: this._searchType,
+      dataset: query.indexName,
     };
   };
 

--- a/src/types/TrieveInstantsearchAdapter.ts
+++ b/src/types/TrieveInstantsearchAdapter.ts
@@ -13,7 +13,6 @@ export interface PerformTrieveSearchResponse {
 export interface TrieveServerConfig {
   url: string;
   apiKey: string;
-  dataset: string;
 }
 
 export type TrieveSearchClient = Pick<SearchClient, "search">;

--- a/src/types/TrieveSearchAPIRequest.ts
+++ b/src/types/TrieveSearchAPIRequest.ts
@@ -48,4 +48,4 @@ export interface TrieveOptionalSearchAPIRequest {
 }
 
 export type TrieveSearchAPIRequest = TrieveRequiredSearchAPIRequest &
-  TrieveOptionalSearchAPIRequest;
+  TrieveOptionalSearchAPIRequest & { dataset: string };


### PR DESCRIPTION
fix dataset should be taken from instantsearch component instead of adapter

before:

```ts
const trieveInstantsearchAdapter = new TrieveInstantsearchAdapter({
  server: {
    apiKey: "tr-xxxxx",
    url: "https://api.trieve.ai",
    dataset: "076e26b3-13df-4920-811b-3d0caa0d3a1e",
  },
  searchType: "fulltext",
});

const searchClient = trieveInstantsearchAdapter.searchClient;


function App() {
  return (
      <InstantSearch searchClient={searchClient}>
        <SearchBox />
        <Hits />
      </InstantSearch>
  );
}

export default App;
```

now:

```ts
const trieveInstantsearchAdapter = new TrieveInstantsearchAdapter({
  server: {
    apiKey: "tr-xxxxx",
    url: "https://api.trieve.ai",
  },
  searchType: "fulltext",
});

const searchClient = trieveInstantsearchAdapter.searchClient;


function App() {
  return (
      <InstantSearch
        indexName="076e26b3-13df-4920-811b-3d0caa0d3a1e"
        searchClient={searchClient}
      >
        <SearchBox />
        <Hits />
      </InstantSearch>
  );
}

export default App;
```

