### PR TITLE
cleanup: bring trieve typedefs inline with serde from Rust repo

### DIFF
--- a/src/TrieveInstantsearchAdapter.ts
+++ b/src/TrieveInstantsearchAdapter.ts
@@ -5,7 +5,7 @@ import {
 
 import {
   TrieveSearchAPIRequest,
-  TrieveSearchType,
+  SearchMethod,
 } from "./types/TrieveSearchAPIRequest";
 
 import {
@@ -18,7 +18,7 @@ import {
 import axios from "axios";
 
 export default class TrieveInstantsearchAdapter {
-  private _searchType: TrieveSearchType;
+  private _searchType: SearchMethod;
   private _serverConfig: TrieveServerConfig;
   public searchClient: TrieveSearchClient;
 
@@ -63,7 +63,7 @@ export default class TrieveInstantsearchAdapter {
           {
             headers: {
               Authorization: `Bearer ${this._serverConfig.apiKey}`,
-              "TR-Dataset": adaptedRequest.dataset,
+              "TR-Dataset": adaptedRequest.datasetId,
               "X-API-Version": "2.0",
             },
           }
@@ -84,7 +84,7 @@ export default class TrieveInstantsearchAdapter {
     return {
       query: query.params?.query || " ",
       search_type: this._searchType,
-      dataset: query.indexName,
+      datasetId: query.indexName,
     };
   };
 

--- a/src/types/TrieveInstantsearchAdapter.ts
+++ b/src/types/TrieveInstantsearchAdapter.ts
@@ -1,11 +1,11 @@
 import { SearchClient } from "algoliasearch-helper/types/algoliasearch";
 
-import { TrieveSearchType } from "./TrieveSearchAPIRequest";
+import { SearchMethod } from "./TrieveSearchAPIRequest";
 
-import { TrieveSearchAPIResponse } from "./TrieveSearchAPIResponse";
+import { SearchResponseBody } from "./TrieveSearchAPIResponse";
 
 export interface PerformTrieveSearchResponse {
-  apiResponse: TrieveSearchAPIResponse;
+  apiResponse: SearchResponseBody;
   processingTime: number;
   query: string;
 }
@@ -19,5 +19,5 @@ export type TrieveSearchClient = Pick<SearchClient, "search">;
 
 export interface TrieveInstantsearchAdapterConfig {
   server: TrieveServerConfig;
-  searchType: TrieveSearchType;
+  searchType: SearchMethod;
 }

--- a/src/types/TrieveSearchAPIRequest.ts
+++ b/src/types/TrieveSearchAPIRequest.ts
@@ -1,51 +1,97 @@
-interface LocationInterface {
+export interface GeoInfo {
   lat: number;
   lon: number;
 }
 
-interface LocationBias {
+interface GeoInfoWithBias {
   bias: number;
-  location: LocationInterface;
+  location: GeoInfo;
 }
 
-interface Filters {
+interface Range {
+  gte?: number;
+  lte?: number;
+  gt?: number;
+  lt?: number;
+}
+
+interface DateRange {
+  gte?: string;
+  lte?: string;
+  gt?: string;
+  lt?: string;
+}
+
+interface LocationBoundingBox {
+  top_left: GeoInfo;
+  bottom_right: GeoInfo;
+}
+
+interface LocationRadius {
+  center: GeoInfo;
+  radius: number;
+}
+
+interface LocationPolygon {
+  exterior: GeoInfo[];
+  interior?: GeoInfo[][];
+}
+interface FieldCondition {
+  field: string;
+  match?: (string | number)[];
+  range?: Range;
+  date_range?: DateRange;
+  location_range?: LocationBoundingBox;
+  geo_radius?: LocationRadius;
+  geo_polygon?: LocationPolygon;
+}
+
+interface HasIdCondition {
+  ids?: string[];
+  tracking_ids?: string[];
+}
+
+type ConditionType = FieldCondition | HasIdCondition;
+
+interface ChunkFilter {
   jsonb_prefilter?: boolean;
-  must?: any[];
-  must_not?: any[];
-  should?: any[];
+  must?: ConditionType[];
+  must_not?: ConditionType[];
+  should?: ConditionType[];
 }
 
 interface TagWeights {
   [key: string]: number;
 }
 
-export type TrieveSearchType = "semantic" | "fulltext" | "hybrid";
+export type SearchMethod = "semantic" | "fulltext" | "hybrid" | "bm25";
 
 interface TrieveRequiredSearchAPIRequest {
   query: string;
-  search_type: TrieveSearchType;
+  search_type: SearchMethod;
 }
 
 export interface TrieveOptionalSearchAPIRequest {
-  content_only?: boolean;
-  filters?: Filters;
-  get_collisions?: boolean;
-  get_total_pages?: boolean;
-  highlight_delimiters?: any[];
-  highlight_max_length?: number;
-  highlight_max_num?: number;
-  highlight_results?: boolean;
-  highlight_threshold?: number;
-  highlight_window?: number;
-  location_bias?: LocationBias;
   page?: number;
   page_size?: number;
+  get_total_pages?: boolean;
+  filters?: ChunkFilter;
   recency_bias?: number;
+  location_bias?: GeoInfoWithBias;
+  use_weights?: boolean;
+  tag_weights?: TagWeights;
+  highlight_results?: boolean;
+  highlight_threshold?: number;
+  highlight_delimiters?: string[];
+  highlight_max_length?: number;
+  highlight_max_num?: number;
+  highlight_window?: number;
   score_threshold?: number;
   slim_chunks?: boolean;
-  tag_weights?: TagWeights;
-  use_weights?: boolean;
+  content_only?: boolean;
+  use_reranker?: boolean;
+  use_quote_negated_terms?: boolean;
 }
 
 export type TrieveSearchAPIRequest = TrieveRequiredSearchAPIRequest &
-  TrieveOptionalSearchAPIRequest & { dataset: string };
+  TrieveOptionalSearchAPIRequest & { datasetId: string };

--- a/src/types/TrieveSearchAPIResponse.ts
+++ b/src/types/TrieveSearchAPIResponse.ts
@@ -1,28 +1,29 @@
-export interface TrieveSearchAPIResponse {
-  chunks: ChunkElement[];
+import { GeoInfo } from "./TrieveSearchAPIRequest";
+
+export interface SearchResponseBody {
+  chunks: ScoreChunk[];
   total_pages: number;
 }
 
-export interface ChunkElement {
-  chunk: ChunkChunk;
+export interface ScoreChunk {
+  chunk: Chunk;
   highlights: string[];
   score: number;
 }
 
-export interface ChunkChunk {
+export interface Chunk {
   id: string;
-  link: string;
-  qdrant_point_id: string;
-  created_at: Date;
-  updated_at: Date;
-  chunk_html: string;
-  metadata: { [key: string]: string };
-  tracking_id: string;
-  time_stamp: null;
+  link: string | null;
+  created_at: string;
+  updated_at: string;
+  chunk_html: string | null;
+  metadata: object | null;
+  tracking_id: string | null;
+  time_stamp: string | null;
   dataset_id: string;
   weight: number;
-  location: null;
-  image_urls: null;
-  tag_set: string[];
-  num_value: null;
+  location: GeoInfo | null;
+  image_urls: string[] | null;
+  tag_set: string[] | null;
+  num_value: number | null;
 }


### PR DESCRIPTION
Point of this PR is to bring the type defs inline with that of the Serde defs in the Rust code. The type defs come mostly from this file - https://github.com/devflowinc/trieve/blob/main/server/src/handlers/chunk_handler.rs

Really would like to do this via openapi-generator, but it's not quite clean enough to work. 